### PR TITLE
Remove duplicate key warning

### DIFF
--- a/lib/formats/epub.rb
+++ b/lib/formats/epub.rb
@@ -15,7 +15,6 @@ class Peregrin::Epub
   MIMETYPE_MAP = {
     '.xhtml' => 'application/xhtml+xml',
     '.odt' => 'application/x-dtbook+xml',
-    '.odt' => 'application/x-dtbook+xml',
     '.ncx' => 'application/x-dtbncx+xml',
     '.epub' => 'application/epub+zip'
   }


### PR DESCRIPTION
Est-ce qu'on peut se débarasser du warning?

_warning: duplicated key at line 18 ignored: ".odt"_
